### PR TITLE
Fail if an image is not given

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -65,6 +65,15 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_METADATA_EXTRA_TAGS ; th
   unset result
 fi
 
+
+# Input validation
+##################
+
+if [ "${#images[@]}" -eq 0 ]; then
+  echo "🚨 :docker-metadata: specifying an output image is required."
+  exit 1
+fi
+
 # Temporary output definitions
 ##############################
 

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -255,3 +255,13 @@ export BUILDKITE_PLUGIN_DOCKER_METADATA_DEBUG=true
   # Cleanup
   rm -r "$dir"
 }
+
+@test "fails if an image is missing" {
+
+  # We can't use bats' `run` function because it executes in a subshell
+  # and we'll loose the environment variables.
+  run "$PWD/hooks/environment"
+
+  assert_failure
+  assert_output --partial "specifying an output image is required."
+}


### PR DESCRIPTION
We were missing that validation, and buildkite's in-built parameter
validation didn't catch it...

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
