### PR TITLE
Use git tag for label and tag

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -65,6 +65,7 @@ if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_METADATA_EXTRA_TAGS ; th
   unset result
 fi
 
+git_tag="${BUILDKITE_TAG:-}"
 
 # Input validation
 ##################
@@ -86,7 +87,11 @@ docker_labels=()
 # TODO(jaosorior): Make these configurable through buildkite parameters
 docker_labels+=("org.opencontainers.image.source=$BUILDKITE_REPO")
 docker_labels+=("org.opencontainers.image.revision=$BUILDKITE_COMMIT")
-docker_labels+=("org.opencontainers.image.version=$BUILDKITE_COMMIT")
+if [ -n "$git_tag" ]; then
+  docker_labels+=("org.opencontainers.image.version=$git_tag")
+else
+  docker_labels+=("org.opencontainers.image.version=$BUILDKITE_COMMIT")
+fi
 
 # Uses different options for `date` depending on the OS
 docker_labels+=("org.opencontainers.image.created=$(date --iso-8601=seconds 2> /dev/null || date -I'seconds')")
@@ -104,8 +109,6 @@ if [ -n "$vendor" ]; then
 fi
 
 # TODO(jaosorior): Figure out what label to use to populate team information
-
-# TODO(jaosorior): Figure out what label to use to populate team information
 #
 # set_teams=$BUILDKITE_PLUGIN_DOCKER_METADATA_SET_TEAMS
 # if [[ "${set_teams}" == "true" ]]; then
@@ -115,6 +118,12 @@ fi
 for image in "${images[@]}" ; do
   # Set revision
   docker_tags+=("${image}:${BUILDKITE_COMMIT}")
+
+  # Label for the version/tag
+  if [ -n "$git_tag" ]; then
+    docker_tags+=("${image}:${git_tag}")
+  fi
+
   for tag in "${extra_tags[@]}" ; do
     docker_tags+=("${image}:${tag}")
   done

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -35,6 +35,9 @@ export BUILDKITE_PLUGIN_DOCKER_METADATA_DEBUG=true
   refute grep -E "^org.opencontainers.image.licenses=.*$" "$dir/labels"
   refute grep -E "^org.opencontainers.image.vendor=.*$" "$dir/labels"
 
+  # When no buildkite tag (or git tag) is available, the version is the commit.
+  assert grep -E "^org.opencontainers.image.version=$BUILDKITE_COMMIT$" "$dir/labels"
+
   # Cleanup
   rm -r "$dir"
 }
@@ -264,4 +267,37 @@ export BUILDKITE_PLUGIN_DOCKER_METADATA_DEBUG=true
 
   assert_failure
   assert_output --partial "specifying an output image is required."
+}
+
+@test "Creates a tag and a label if the git tag is defined" {
+  export BUILDKITE_PLUGIN_DOCKER_METADATA_IMAGES_0="foo/bar"
+  export BUILDKITE_TAG="v0.1.0"
+
+  # We can't use bats' `run` function because it executes in a subshell
+  # and we'll loose the environment variables.
+  run "$PWD/hooks/environment"
+
+  assert_success
+  assert_output --regexp "DOCKER_METADATA_DIR: '.*'"
+  local dir=$(echo "$output" | sed -n "s/.*DOCKER_METADATA_DIR: '\(.*\)'/\1/p")
+  assert [ -n "$dir" ]
+  assert [ -d "$dir" ]
+  assert [ -f "$dir/labels" ]
+  assert [ -f "$dir/tags" ]
+
+  # Check tags
+  assert grep -E "^foo/bar:$BUILDKITE_COMMIT$" "$dir/tags"
+  assert grep -E "^foo/bar:$BUILDKITE_TAG$" "$dir/tags"
+
+  # Check labels
+  assert grep -E "^org.opencontainers.image.source=$BUILDKITE_REPO$" "$dir/labels"
+  assert grep -E "^org.opencontainers.image.revision=$BUILDKITE_COMMIT$" "$dir/labels"
+  assert grep -E "^org.opencontainers.image.version=$BUILDKITE_TAG$" "$dir/labels"
+  assert grep -E "^org.opencontainers.image.created=.*$" "$dir/labels"
+  refute grep -E "^org.opencontainers.image.title=.*$" "$dir/labels"
+  refute grep -E "^org.opencontainers.image.licenses=.*$" "$dir/labels"
+  refute grep -E "^org.opencontainers.image.vendor=.*$" "$dir/labels"
+
+  # Cleanup
+  rm -r "$dir"
 }


### PR DESCRIPTION
If a git tag is available through the `BUILDKITE_TAG` environment
variable, the version label will be set to this. We'll also
automatically create a container tag for the git tag.

Closes https://github.com/equinixmetal-buildkite/docker-metadata-buildkite-plugin/issues/1

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
