### PR TITLE
Add basic CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run:
         make lint
 
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run:
         make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+---
+name: Test
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run:
+        make lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run:
+        make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        # This fetches all branches and tags, which helps us lint that we're using the current version
+        # in our examples.
+        fetch-depth: 0
     - run:
         make lint
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: lint
 lint: | plugin-arg-docs
-	docker run -it --rm -v "$$PWD:/plugin:ro" buildkite/plugin-linter --id equinixmetal-buildkite/docker-metadata
+	docker run --rm -v "$$PWD:/plugin:ro" buildkite/plugin-linter --id equinixmetal-buildkite/docker-metadata
 
 .PHONY: test
 test:
-	docker run -it --rm -v "$$PWD:/plugin:ro" buildkite/plugin-tester
+	docker run --rm -v "$$PWD:/plugin:ro" buildkite/plugin-tester
 
 .PHONY: plugin-arg-docs
 plugin-arg-docs: ## Ensures that the plugin arguments are documented

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      - equinixmetal-buildkite/docker-metadata#v0.1.0:
+      - equinixmetal-buildkite/docker-metadata#v0.1.2:
           images:
           - 'my-org/my-image'
 ```


### PR DESCRIPTION
This adds a GitHub actions based CI that runs two jobs:

* test - actual bats tests
* lint - lints the plugin.yml

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
