### PR TITLE
Pin Buildkite test images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
+BUILDKITE_TESTER_IMAGE=buildkite/plugin-tester:v2.0.0
+
+# NOTE(jaosorior): This hasn't been released in two years...
+#                  we should ask for a fix.
+BUILDKITE_LINTER_IMAGE=buildkite/plugin-linter:latest
+
 .PHONY: lint
 lint: | plugin-arg-docs
-	docker run --rm -v "$$PWD:/plugin:ro" buildkite/plugin-linter --id equinixmetal-buildkite/docker-metadata
+	docker run --rm -v "$$PWD:/plugin:ro" $(BUILDKITE_LINTER_IMAGE) --id equinixmetal-buildkite/docker-metadata
 
 .PHONY: test
 test:
-	docker run --rm -v "$$PWD:/plugin:ro" buildkite/plugin-tester
+	docker run --rm -v "$$PWD:/plugin:ro" $(BUILDKITE_TESTER_IMAGE)
 
 .PHONY: plugin-arg-docs
 plugin-arg-docs: ## Ensures that the plugin arguments are documented

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ls
     plugins:
-      - equinixmetal-buildkite/docker-metadata#v0.1.2:
+      - equinixmetal-buildkite/docker-metadata#v1.0.0:
           images:
           - 'my-org/my-image'
 ```


### PR DESCRIPTION
This ensures that we use variable in our Makefile to track the buildkite
test images we use. Note that we only pin to an image we can track (the
linter has no versioning yet). This ensures that we don't get hit by the
recently broken bats-mock update which comes as part of v3.0.0.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
